### PR TITLE
Change: Name of "Quick Save" in Matérias for "Save"

### DIFF
--- a/app/schedule/components/SaveScheduleDialog.tsx
+++ b/app/schedule/components/SaveScheduleDialog.tsx
@@ -56,7 +56,7 @@ function QuickSaveButton() {
       disabled={isCreating || !currentScheduleId}
     >
       <Save className="h-4 w-4" />
-      {isCreating ? "Saving..." : "Quick Save"}
+      {isCreating ? "Saving..." : "Save"}
     </Button>
   );
 }
@@ -123,6 +123,7 @@ function CreateScheduleDialog() {
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="Enter schedule description (optional)"
+              className="w-full h-32 resize-none border rounded-md p-2"
             />
           </div>
         </div>


### PR DESCRIPTION
Changing the name of save button in "Matérias" for only "Save" and blocking the box of Schedule Description