### PR TITLE
removing local auth

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -5,21 +5,21 @@
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
+// import { Label } from "@/components/ui/label";
 import GoogleLoginButton from "./google-button";
-import { Separator } from "@/components/ui/separator";
-import Link from "next/link";
-import SignInForm from "./signinForm";
+// import { Separator } from "@/components/ui/separator";
+// import Link from "next/link";
+// import SignInForm from "./signinForm";
 
-function SeparatorWithText(props: { text: string; style: string }) {
-  return (
-    <div className={`flex items-center space-x-4 ${props.style}`}>
-      <Separator className="flex-1" />
-      <span className="text-sm text-muted-foreground">{props.text}</span>
-      <Separator className="flex-1" />
-    </div>
-  );
-}
+// function SeparatorWithText(props: { text: string; style: string }) {
+//   return (
+//     <div className={`flex items-center space-x-4 ${props.style}`}>
+//       <Separator className="flex-1" />
+//       <span className="text-sm text-muted-foreground">{props.text}</span>
+//       <Separator className="flex-1" />
+//     </div>
+//   );
+// }
 
 export default function Login() {
   return (

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -37,16 +37,16 @@ export default function Login() {
           <div className="w-full flex justify-center">
             <GoogleLoginButton style="w-full cursor-pointer" />
           </div>
-          <SeparatorWithText style="my-5" text="OU CONTINUE COM" />
+          {/* <SeparatorWithText style="my-5" text="OU CONTINUE COM" /> */}
 
-          <SignInForm />
+          {/* <SignInForm /> */}
 
-          <div className="mt-2">
+          {/* <div className="mt-2">
             <Label className="text-md">Não possui uma conta? 😱 </Label>
             <Link href="/auth/signup" className="underline underline-offset-2">
               Crie uma aqui
             </Link>
-          </div>
+          </div> */}
         </CardContent>
       </Card>
     </div>

--- a/components/edit-profile-dialog.tsx
+++ b/components/edit-profile-dialog.tsx
@@ -260,7 +260,7 @@ const handleSubmit = async (e: React.FormEvent) => {
               />
             </div>
 
-            <div className="space-y-2">
+            {/* <div className="space-y-2">
               <Label htmlFor="email">Email</Label>
               <Input
                 id="email"
@@ -272,7 +272,7 @@ const handleSubmit = async (e: React.FormEvent) => {
                 disabled={isLoading}
                 required
               />
-            </div>
+            </div> */}
 
             <div className="space-y-2">
               <Label htmlFor="course">Curso</Label>


### PR DESCRIPTION
This pull request primarily comments out sections of UI related to alternative sign-in methods and profile editing. The main effect is to temporarily hide certain form fields and options from users, likely for development or testing purposes.

UI changes to authentication and profile editing forms:

* Commented out the separator, alternative sign-in form (`SignInForm`), and the "create account" prompt in the `Login` page, leaving only the Google login option visible.
* Commented out the email input field in the profile editing dialog, so users can no longer edit their email address from this form. [[1]](diffhunk://#diff-9ad32f77da004159578dad4688f0733a27790745d298bd94995aa08de10ecdf4L263-R263) [[2]](diffhunk://#diff-9ad32f77da004159578dad4688f0733a27790745d298bd94995aa08de10ecdf4L275-R275)