### PR TITLE
feat: add semester selection, competition scoring, and fix schedule save status

### DIFF
--- a/app/hooks/useCompetitionScores.ts
+++ b/app/hooks/useCompetitionScores.ts
@@ -1,0 +1,45 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCompetitionService, type CompetitionScore, type BatchCompetitionResponse } from "@/app/services/competitionService";
+
+export const useCompetitionScoreQuery = (code: string, enabled = true) => {
+  const { getSingleCompetitionScore } = useCompetitionService();
+  
+  return useQuery<CompetitionScore>({
+    queryKey: ["competitionScore", code],
+    queryFn: () => getSingleCompetitionScore(code),
+    enabled: enabled && !!code,
+    staleTime: 5 * 60 * 1000, // 5 minutes - competition scores don't change often
+    retry: 2,
+  });
+};
+
+export const useBatchCompetitionScoresQuery = (codes: string[], enabled = true) => {
+  const { getBatchCompetitionScores } = useCompetitionService();
+  
+  return useQuery<BatchCompetitionResponse>({
+    queryKey: ["competitionScores", "batch", codes.sort().join(",")],
+    queryFn: () => getBatchCompetitionScores(codes),
+    enabled: enabled && codes.length > 0,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    retry: 2,
+  });
+};
+
+// Mutation for prefetching competition scores (useful for background loading)
+export const usePrefetchCompetitionScores = () => {
+  const { getBatchCompetitionScores } = useCompetitionService();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (codes: string[]) => {
+      const result = await getBatchCompetitionScores(codes);
+      
+      // Cache individual scores for later use
+      result.scores.forEach(score => {
+        queryClient.setQueryData(["competitionScore", score.code], score);
+      });
+      
+      return result;
+    },
+  });
+};

--- a/app/hooks/useSavedSchedules.ts
+++ b/app/hooks/useSavedSchedules.ts
@@ -43,6 +43,7 @@ export const useSavedSchedulesQuery = (isAuthenticated = false) => {
     mutationFn: (data: {
       title: string;
       description?: string;
+      semester?: string;
       plans?: {
         planNumber: number;
         items: {
@@ -59,6 +60,7 @@ export const useSavedSchedulesQuery = (isAuthenticated = false) => {
       const payload: any = {
         title: data.title,
         description: data.description || "",
+        semester: data.semester,
         totalCredits: data.totalCredits || 0,
       };
 
@@ -102,6 +104,7 @@ export const useSavedSchedulesQuery = (isAuthenticated = false) => {
       id: number;
       title: string;
       description?: string;
+      semester?: string;
       plans?: {
         planNumber: number;
         items: {
@@ -118,6 +121,7 @@ export const useSavedSchedulesQuery = (isAuthenticated = false) => {
       const payload: any = {
         title: data.title,
         description: data.description || "",
+        semester: data.semester,
         totalCredits: data.totalCredits || 0,
       };
 

--- a/app/hooks/useSemesters.ts
+++ b/app/hooks/useSemesters.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { semestersService } from '@/app/services/semestersService';
+
+export function useSemestersQuery() {
+  return useQuery({
+    queryKey: ['semesters'],
+    queryFn: () => semestersService.getSemesters(),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 10 * 60 * 1000, // 10 minutes
+    retry: 2,
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import localFont from "next/font/local";
 import "./globals.css";
 import { Menubar, MenubarMenu, MenubarTrigger } from "@/components/ui/menubar";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { ThemeProvider } from "@/components/theme-provider";
 import Providers from "./providers";
 import ProfileOptions from "@/app/profile/ProfileOptions";
@@ -39,65 +40,67 @@ export default function RootLayout({
       >
         <Providers>
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
-            <ToastContainer
-              position="bottom-right"
-              autoClose={5000}
-              hideProgressBar={false}
-              newestOnTop={false}
-              closeOnClick
-              rtl={false}
-              pauseOnFocusLoss
-              draggable
-              pauseOnHover
-              theme="colored"
-            />
-            <div className="flex flex-col min-h-full">
-              <Menubar className="flex justify-between items-center h-16">
-                <div className="flex space-x-4 items-center">
-                  <MenubarMenu>
-                    <Link href={"/"}>
-                      <div className="text-sm lg:text-base flex gap-2 items-center ml-6">
-                        <span className="hidden dark:block">
-                          <Image src={logo} alt="grade" width={20} height={20} />
-                        </span>
-                        <span className="block dark:hidden">
-                          <Image src={BlackLogo} alt="grade" width={20} height={20} />
-                        </span>
-                        MatrUFSC 2.0
-                      </div>
-                    </Link>
-                  </MenubarMenu>
-                  <MenubarMenu>
-                    <MenubarTrigger className="flex transition-colors duration-400 hover:bg-gray-800 cursor-pointer">
-                      <Link href={"/schedule"}>Matérias</Link>
-                    </MenubarTrigger>
-                  </MenubarMenu>
-                  {/* <MenubarMenu>
-                    <MenubarTrigger className="flex transition-colors duration-400 hover:bg-gray-800 cursor-pointer">
-                      <Link href={"/professors"}>Professores</Link>
-                    </MenubarTrigger>
-                  </MenubarMenu> */}
-                  <MenubarMenu>
-                    <MenubarTrigger className="flex transition-colors duration-400 hover:bg-gray-800 cursor-pointer">
-                      <Link href={"/groups"}>Grupos e Amizades</Link>
-                    </MenubarTrigger>
-                  </MenubarMenu>
-                </div>
+            <TooltipProvider delayDuration={0} skipDelayDuration={0}>
+              <ToastContainer
+                position="bottom-right"
+                autoClose={5000}
+                hideProgressBar={false}
+                newestOnTop={false}
+                closeOnClick
+                rtl={false}
+                pauseOnFocusLoss
+                draggable
+                pauseOnHover
+                theme="colored"
+              />
+              <div className="flex flex-col min-h-full">
+                <Menubar className="flex justify-between items-center h-16">
+                  <div className="flex space-x-4 items-center">
+                    <MenubarMenu>
+                      <Link href={"/"}>
+                        <div className="text-sm lg:text-base flex gap-2 items-center ml-6">
+                          <span className="hidden dark:block">
+                            <Image src={logo} alt="grade" width={20} height={20} />
+                          </span>
+                          <span className="block dark:hidden">
+                            <Image src={BlackLogo} alt="grade" width={20} height={20} />
+                          </span>
+                          MatrUFSC 2.0
+                        </div>
+                      </Link>
+                    </MenubarMenu>
+                    <MenubarMenu>
+                      <MenubarTrigger className="flex transition-colors duration-400 hover:bg-gray-800 cursor-pointer">
+                        <Link href={"/schedule"}>Matérias</Link>
+                      </MenubarTrigger>
+                    </MenubarMenu>
+                    {/* <MenubarMenu>
+                      <MenubarTrigger className="flex transition-colors duration-400 hover:bg-gray-800 cursor-pointer">
+                        <Link href={"/professors"}>Professores</Link>
+                      </MenubarTrigger>
+                    </MenubarMenu> */}
+                    <MenubarMenu>
+                      <MenubarTrigger className="flex transition-colors duration-400 hover:bg-gray-800 cursor-pointer">
+                        <Link href={"/groups"}>Grupos e Amizades</Link>
+                      </MenubarTrigger>
+                    </MenubarMenu>
+                  </div>
 
-                <div className="flex gap-2">
-                  <MenubarMenu>
-                    <Theme />
-                    <NotificationsDropdown />
-                    <MenubarTrigger className="ml-auto">
-                      <ProfileOptions />
-                    </MenubarTrigger>
-                  </MenubarMenu>
-                </div>
-              </Menubar>
-              <main className="flex-1">{children}</main>
-              <Footer />
-              <FeedbackButton />
-            </div>
+                  <div className="flex gap-2">
+                    <MenubarMenu>
+                      <Theme />
+                      <NotificationsDropdown />
+                      <MenubarTrigger className="ml-auto">
+                        <ProfileOptions />
+                      </MenubarTrigger>
+                    </MenubarMenu>
+                  </div>
+                </Menubar>
+                <main className="flex-1">{children}</main>
+                <Footer />
+                <FeedbackButton />
+              </div>
+            </TooltipProvider>
           </ThemeProvider>
         </Providers>
         <Toaster richColors position="bottom-right" />

--- a/app/schedule/components/CompetitionBadge.tsx
+++ b/app/schedule/components/CompetitionBadge.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Loader2 } from "lucide-react";
+
+interface CompetitionBadgeProps {
+  score?: {
+    averageOrdersWithoutVacancy: number;
+    category: "Baixa" | "Média" | "Alta";
+    semesterCount: number;
+  };
+  isLoading?: boolean;
+  error?: Error | null;
+}
+
+const getCategoryColor = (category: "Baixa" | "Média" | "Alta") => {
+  switch (category) {
+    case "Baixa":
+      return "bg-green-100 text-green-800 border-green-300 hover:bg-green-200 dark:bg-green-900 dark:text-green-200 dark:border-green-700 dark:hover:bg-green-800";
+    case "Média":
+      return "bg-yellow-100 text-yellow-800 border-yellow-300 hover:bg-yellow-200 dark:bg-yellow-900 dark:text-yellow-200 dark:border-yellow-700 dark:hover:bg-yellow-800";
+    case "Alta":
+      return "bg-red-100 text-red-800 border-red-300 hover:bg-red-200 dark:bg-red-900 dark:text-red-200 dark:border-red-700 dark:hover:bg-red-800";
+    default:
+      return "bg-gray-100 text-gray-800 border-gray-300 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-700";
+  }
+};
+
+const getClassificationLimits = () => {
+  return "Baixa: 0-15 | Média: 15-30 | Alta: 30+";
+};
+
+export default function CompetitionBadge({ score, isLoading, error }: CompetitionBadgeProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-1">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        <span className="text-xs text-muted-foreground">Carregando...</span>
+      </div>
+    );
+  }
+
+  if (error || !score) {
+    return (
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>
+          <Button 
+            variant="outline" 
+            size="sm"
+            className="text-xs h-6 px-2 cursor-help"
+          >
+            —
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <p>Concorrência indisponível</p>
+          {error && <p className="text-xs text-muted-foreground">{error.message}</p>}
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  const tooltipContent = (
+    <div className="space-y-1">
+      <p className="font-semibold text-sm">
+        Pedidos sem vaga: {Math.round(score.averageOrdersWithoutVacancy)}
+      </p>
+      <p className="text-xs text-muted-foreground">
+        {getClassificationLimits()}
+      </p>
+      <p className="text-xs text-muted-foreground">
+        Baseado em {score.semesterCount} semestre{score.semesterCount !== 1 ? 's' : ''}
+      </p>
+    </div>
+  );
+
+  return (
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={`text-xs h-6 px-2 cursor-help border ${getCategoryColor(score.category)}`}
+        >
+          {score.category}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-xs">
+        {tooltipContent}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/app/schedule/components/SaveScheduleDialog.tsx
+++ b/app/schedule/components/SaveScheduleDialog.tsx
@@ -30,7 +30,7 @@ import { SavedSchedule } from "@/app/services/savedSchedulesService";
 import LoginSuggestionDialog from "./LoginSuggestionDialog";
 
 export default function SaveScheduleDialog() {
-  const { scheduleSubjects, currentScheduleId, scheduleTitle, clearLocalSchedule, resetToDefault, setCurrentScheduleId, setScheduleTitle, plansData, markAsSaved, calculateTotalCredits, getPlansDataForSave } = useSubjects();
+  const { scheduleSubjects, currentScheduleId, scheduleTitle, clearLocalSchedule, resetToDefault, setCurrentScheduleId, setScheduleTitle, plansData, markAsSaved, calculateTotalCredits, getPlansDataForSave, selectedSemester, localSaveStatus } = useSubjects();
   const { isAuthenticated } = useSession();
   const { updateScheduleAsync, createSchedule, deleteSchedule, savedSchedules, isCreating, isUpdating, isDeleting, isLoading } = useSavedSchedulesQuery(isAuthenticated);
   
@@ -86,6 +86,7 @@ export default function SaveScheduleDialog() {
           id: currentScheduleId,
           title: scheduleTitle,
           description: currentSchedule.description || '',
+          semester: selectedSemester || undefined,
           plans: getPlansDataForSave(),
           totalCredits: calculateTotalCredits(),
         });
@@ -102,7 +103,7 @@ export default function SaveScheduleDialog() {
   };
 
   const handleCreateNewClick = () => {
-    if (isDirty) {
+    if (localSaveStatus === "modified") {
       setShowDiscardAlert(true);
     } else {
       clearLocalSchedule();
@@ -154,6 +155,7 @@ export default function SaveScheduleDialog() {
     createSchedule({
       title: title.trim(),
       description: description.trim(),
+      semester: selectedSemester || undefined,
       plans: getPlansDataForSave(),
       totalCredits: calculateTotalCredits(),
     }, {
@@ -186,6 +188,7 @@ export default function SaveScheduleDialog() {
             id: eventScheduleId,
             title: eventTitle,
             description: currentSchedule.description || '',
+            semester: selectedSemester || undefined,
             plans: eventPlans,
             totalCredits: calculateTotalCredits(),
           });

--- a/app/schedule/components/SavedSchedulesDialog.tsx
+++ b/app/schedule/components/SavedSchedulesDialog.tsx
@@ -42,6 +42,7 @@ import useAxios from "@/app/api/AxiosInstance";
 import { SubjectsType } from "../types/dataType";
 import { getUniqueColorPair, resetColorUsage } from "../utils/colorUtils";
 import ShareScheduleDialog from "./ShareScheduleDialog";
+import { useCompetitionService } from "@/app/services/competitionService";
 
 export default function SavedSchedulesDialog() {
   const [open, setOpen] = useState(false);
@@ -55,13 +56,21 @@ export default function SavedSchedulesDialog() {
     null
   );
   const [modalJustOpened, setModalJustOpened] = useState(false);
+  const [showUnsavedChangesAlert, setShowUnsavedChangesAlert] = useState(false);
+  const [scheduleToLoad, setScheduleToLoad] = useState<SavedSchedule | null>(null);
   const { isAuthenticated } = useSession();
   const [showLoginDialog, setShowLoginDialog] = useState(false);
   const { savedSchedules, isLoading, deleteSchedule, isDeleting } =
     useSavedSchedulesQuery(isAuthenticated);
-  const { currentScheduleId, setCurrentScheduleId, loadFullSchedule } =
+  const { currentScheduleId, setCurrentScheduleId, loadFullSchedule, setSelectedSemesterDirectly, localSaveStatus } =
     useSubjects();
   const { getSubjectsByCodes } = useAxios();
+  const { getBatchCompetitionScores } = useCompetitionService();
+
+  const formatSemesterDisplay = (semester: string | undefined) => {
+    if (!semester) return "-";
+    return semester.replace(/\//g, '.');
+  };
 
   const handleDelete = (id: number) => {
     setSelectedSchedule(id);
@@ -82,6 +91,19 @@ export default function SavedSchedulesDialog() {
         setCurrentScheduleId(null);
       }
     }
+  };
+
+  const confirmLoadWithUnsavedChanges = () => {
+    if (scheduleToLoad) {
+      setShowUnsavedChangesAlert(false);
+      handleLoadScheduleDirectly(scheduleToLoad);
+      setScheduleToLoad(null);
+    }
+  };
+
+  const cancelLoadWithUnsavedChanges = () => {
+    setShowUnsavedChangesAlert(false);
+    setScheduleToLoad(null);
   };
 
   const getAllItems = (schedule: SavedSchedule) => {
@@ -112,7 +134,16 @@ export default function SavedSchedulesDialog() {
     return credits;
   };
 
-  const handleLoadSchedule = async (schedule: SavedSchedule) => {
+  const checkUnsavedChanges = (schedule: SavedSchedule) => {
+    if (localSaveStatus === "modified") {
+      setScheduleToLoad(schedule);
+      setShowUnsavedChangesAlert(true);
+      return;
+    }
+    handleLoadScheduleDirectly(schedule);
+  };
+
+  const handleLoadScheduleDirectly = async (schedule: SavedSchedule) => {
     if (loadingScheduleId === schedule.idsavedschedule) return;
 
     try {
@@ -124,10 +155,29 @@ export default function SavedSchedulesDialog() {
       console.log("All items to load:", allItems);
       const subjectCodes = allItems.map((item) => item.subjectCode);
 
-      const subjects = await getSubjectsByCodes(subjectCodes);
+      // Fetch subjects and competition scores in parallel
+      const [subjects, competitionResult] = await Promise.allSettled([
+        getSubjectsByCodes(subjectCodes),
+        getBatchCompetitionScores(subjectCodes)
+      ]);
 
-      if (!subjects || subjects.length === 0 && allItems.length > 0) {
+      // Handle subjects data (required)
+      if (subjects.status === 'rejected') {
+        throw new Error("Failed to fetch subjects data");
+      }
+
+      if (!subjects.value || subjects.value.length === 0 && allItems.length > 0) {
         throw new Error("No subjects found for the schedule");
+      }
+
+      // Handle competition scores (optional)
+      const competitionMap = new Map();
+      if (competitionResult.status === 'fulfilled') {
+        competitionResult.value.scores.forEach(score => {
+          competitionMap.set(score.code, score);
+        });
+      } else {
+        console.warn("Failed to fetch competition scores:", competitionResult.reason);
       }
 
       const getSubjectsForPlan = (items: typeof allItems) => {
@@ -140,12 +190,24 @@ export default function SavedSchedulesDialog() {
 
       const getSearchedSubjectsForPlan = (items: typeof allItems) => {
         const planSubjectCodes = items.map((i) => String(i.subjectCode));
-        return subjects
-          .filter((s: SubjectsType) => planSubjectCodes.includes(s.code))
-          .map((subject: SubjectsType) => ({
+        let filteredSubjects = subjects.value
+          .filter((s: SubjectsType) => planSubjectCodes.includes(s.code));
+        
+        // Filter by saved semester if available
+        if (schedule.semester) {
+          filteredSubjects = filteredSubjects.filter((s: SubjectsType) => 
+            s.semester?.semester === schedule.semester
+          );
+        }
+        
+        return filteredSubjects.map((subject: SubjectsType) => {
+          const competition = competitionMap.get(subject.code);
+          return {
             ...subject,
             color: getUniqueColorPair(),
-          }));
+            competition: competition || undefined,
+          };
+        });
       };
 
       const createEmptyPlan = () => ({
@@ -187,6 +249,11 @@ export default function SavedSchedulesDialog() {
         initializedPlans,
       });
 
+      // Set the semester from saved schedule
+      if (schedule.semester) {
+        setSelectedSemesterDirectly(schedule.semester);
+      }
+
       setOpen(false);
       toast.success("Grade carregada com sucesso");
     } catch (error) {
@@ -225,7 +292,7 @@ export default function SavedSchedulesDialog() {
             </span>
           </Button>
         </DialogTrigger>
-        <DialogContent className="sm:max-w-[1000px]">
+        <DialogContent className="sm:max-w-[1100px]">
           <DialogHeader>
             <DialogTitle>Grades salvas</DialogTitle>
             <DialogDescription>
@@ -243,16 +310,17 @@ export default function SavedSchedulesDialog() {
           ) : (
             <div className="max-h-[400px] overflow-y-auto">
               <Table className="table-fixed">
-                <TableHeader>
-                  <TableRow>
-                     <TableHead className="w-[110px]">Comentários</TableHead>
-                     <TableHead className="flex-1">Título</TableHead>
-                     <TableHead className="w-[100px] text-center">Plano 1</TableHead>
-                     <TableHead className="w-[100px] text-center">Plano 2</TableHead>
-                     <TableHead className="w-[100px] text-center">Plano 3</TableHead>
-                     <TableHead className="w-[140px] text-right">Ações</TableHead>
-                  </TableRow>
-                </TableHeader>
+                 <TableHeader>
+                   <TableRow>
+                      <TableHead className="w-[110px]">Comentários</TableHead>
+                      <TableHead className="flex-1">Título</TableHead>
+                      <TableHead className="w-[90px] text-center">Semestre</TableHead>
+                      <TableHead className="w-[100px] text-center">Plano 1</TableHead>
+                      <TableHead className="w-[100px] text-center">Plano 2</TableHead>
+                      <TableHead className="w-[100px] text-center">Plano 3</TableHead>
+                      <TableHead className="w-[140px] text-right">Ações</TableHead>
+                   </TableRow>
+                 </TableHeader>
                 <TableBody>
                   {(Array.isArray(savedSchedules) ? savedSchedules : []).map((schedule) => {
                     const credits = getCreditsPerPlan(schedule);
@@ -278,14 +346,17 @@ export default function SavedSchedulesDialog() {
                              </HoverCardContent>
                            </HoverCard>
                         </TableCell>
-                        <TableCell className="flex-1 min-w-0">
-                          <div className="line-clamp-2 break-words">
-                            {schedule.title}
-                          </div>
-                        </TableCell>
-                         <TableCell className="w-[100px] text-center">
-                           {credits.plan1 > 0 ? `${credits.plan1} créditos` : "-"}
+                         <TableCell className="flex-1 min-w-0">
+                           <div className="line-clamp-2 break-words">
+                             {schedule.title}
+                           </div>
                          </TableCell>
+                         <TableCell className="w-[90px] text-center">
+                           {formatSemesterDisplay(schedule.semester)}
+                         </TableCell>
+                          <TableCell className="w-[100px] text-center">
+                            {credits.plan1 > 0 ? `${credits.plan1} créditos` : "-"}
+                          </TableCell>
                          <TableCell className="w-[100px] text-center">
                            {credits.plan2 > 0 ? `${credits.plan2} créditos` : "-"}
                          </TableCell>
@@ -297,7 +368,7 @@ export default function SavedSchedulesDialog() {
                             <Button
                               variant="outline"
                               size="icon"
-                              onClick={() => handleLoadSchedule(schedule)}
+                              onClick={() => checkUnsavedChanges(schedule)}
                               disabled={loadingScheduleId === schedule.idsavedschedule || isDeleting}
                               className="h-8 w-8"
                             >
@@ -353,6 +424,29 @@ export default function SavedSchedulesDialog() {
                   className="bg-destructive text-destructive-foreground"
                 >
                   Deletar
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+
+          <AlertDialog open={showUnsavedChangesAlert} onOpenChange={setShowUnsavedChangesAlert}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Mudanças não salvas</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Você tem mudanças não salvas na grade atual. Se continuar, estas mudanças serão perdidas.
+                  Deseja prosseguir mesmo assim?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={cancelLoadWithUnsavedChanges}>
+                  Cancelar
+                </AlertDialogCancel>
+                <AlertDialogAction 
+                  onClick={confirmLoadWithUnsavedChanges}
+                  className="bg-destructive text-destructive-foreground"
+                >
+                  Prosseguir
                 </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>

--- a/app/schedule/components/SearchSubject.tsx
+++ b/app/schedule/components/SearchSubject.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { Check, ChevronsUpDown, Loader2 } from "lucide-react";
 
 import { useSubjects } from "../providers/subjectsContext";
+import { useCompetitionService } from "@/app/services/competitionService";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -37,10 +38,12 @@ export default function SearchSubject({ subjects }: SearchSubjectProps) {
     scheduleSubjects,
     setScheduleSubjects,
     setSelectedSubject,
+    selectedSemester,
   } = useSubjects();
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState("");
   const { getSubject } = useAxios();
+  const { getSingleCompetitionScore } = useCompetitionService();
   const [searchTerm, setSearchTerm] = useState("");
   const [paginationLimit, setPaginationLimit] = useState(PAGE_SIZE);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -51,7 +54,47 @@ export default function SearchSubject({ subjects }: SearchSubjectProps) {
   const filteredSubjects = useMemo(() => {
     const subjectsArray = subjects || [];
 
-    const filtered_subjects = subjectsArray.filter(
+    let semesterFilteredSubjects = subjectsArray;
+    if (selectedSemester) {
+      // Merge .2 and .3 for the same year
+      const parts = selectedSemester.split('.');
+      const suffix = parts[1]; // e.g. "2" or "3"
+      if (suffix === '2' || suffix === '3') {
+        const year = parts[0];
+        const sem2 = `${year}.2`;
+        const sem3 = `${year}.3`;
+        // Collect subjects in either sem2 or sem3
+        const candidates = subjectsArray.filter(
+          (subject) =>
+            subject.semester?.semester === sem2 ||
+            subject.semester?.semester === sem3
+        );
+        // Deduplicate by code preferring sem3 version
+        const byCode = new Map<string, SubjectsType>();
+        for (const subj of candidates) {
+          const existing = byCode.get(subj.code);
+          if (!existing) {
+            byCode.set(subj.code, subj);
+            continue;
+          }
+          const existingSem = existing.semester?.semester;
+          const currentSem = subj.semester?.semester;
+          // If existing is .2 and current is .3, replace (prefer .3)
+          if (existingSem?.endsWith('.2') && currentSem?.endsWith('.3')) {
+            byCode.set(subj.code, subj);
+          }
+          // If existing is .3 and current is .2, keep existing (.3 already preferred)
+        }
+        semesterFilteredSubjects = Array.from(byCode.values());
+      } else {
+        // default exact-match behavior for other semesters (e.g., .1)
+        semesterFilteredSubjects = subjectsArray.filter(
+          (subject) => subject.semester?.semester === selectedSemester
+        );
+      }
+    }
+
+    const filtered_subjects = semesterFilteredSubjects.filter(
       (subject) =>
         subject.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
         subject.code.toLowerCase().includes(searchTerm.toLowerCase())
@@ -61,7 +104,7 @@ export default function SearchSubject({ subjects }: SearchSubjectProps) {
       ...subject,
       name: `${subject.code} - ${subject.name}`,
     }));
-  }, [subjects, searchTerm]);
+  }, [subjects, searchTerm, selectedSemester]);
 
   // Reset pagination whenever the search term changes
   useEffect(() => {
@@ -131,11 +174,28 @@ export default function SearchSubject({ subjects }: SearchSubjectProps) {
       setValue("");
     } else {
       try {
-        const response = await getSubject(subject.idsubject);
+        // Fetch subject data and competition score in parallel
+        const [response, competitionScore] = await Promise.allSettled([
+          getSubject(subject.idsubject),
+          getSingleCompetitionScore(subject.code)
+        ]);
+
+        // Handle subject data
+        if (response.status === 'rejected') {
+          throw new Error('Failed to fetch subject data');
+        }
+
         const dataWithColors = {
-          ...response,
+          ...response.value,
           color: getUniqueColorPair(),
         };
+
+        // Handle competition score (optional - don't fail if it fails)
+        if (competitionScore.status === 'fulfilled') {
+          dataWithColors.competition = competitionScore.value;
+        } else {
+          console.warn(`Failed to fetch competition score for ${subject.code}:`, competitionScore.reason);
+        }
 
         const newScheduleSubject = {
           code: dataWithColors.code,

--- a/app/schedule/components/SelectedSubject.tsx
+++ b/app/schedule/components/SelectedSubject.tsx
@@ -1,7 +1,8 @@
-﻿"use client";
+"use client";
 
 import { useEffect, useState, useRef } from "react";
 import { useSubjects } from "../providers/subjectsContext";
+import { useTheme } from "next-themes";
 import {
   Table,
   TableBody,
@@ -16,6 +17,7 @@ import { ClassesType } from "../types/dataType";
 
 export default function SelectedSubject() {
   const [rowSelection, setRowSelection] = useState<string | null>(null);
+  const { theme } = useTheme();
 
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
   const [maxHeight, setMaxHeight] = useState<string | undefined>(undefined);
@@ -165,7 +167,20 @@ export default function SelectedSubject() {
               onClick={() => handleRowSelect(row)}
               data-state={rowSelection === row.classcode ? "selected" : ""}
             >
-              <TableCell>{row.classcode}</TableCell>
+              <TableCell>
+                <Badge
+                  variant="outline"
+                  className={`${
+                    selectedSubject.color && Array.isArray(selectedSubject.color)
+                      ? theme === "light"
+                        ? selectedSubject.color[0] + " text-black"
+                        : selectedSubject.color[1] + " text-white"
+                      : ""
+                  }`}
+                >
+                  {row.classcode}
+                </Badge>
+              </TableCell>
               <TableCell>
                 {`${row.totalvacancies - row.freevacancies}/${
                   row.totalvacancies

--- a/app/schedule/components/SemesterChangeModal.tsx
+++ b/app/schedule/components/SemesterChangeModal.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+type Props = {
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  pendingSemester: string | null;
+};
+
+export default function SemesterChangeModal({ 
+  open, 
+  onConfirm, 
+  onCancel, 
+  pendingSemester 
+}: Props) {
+  const formatSemester = (semester: string) => {
+    return semester.replace(/\//g, '.');
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Confirmar mudança de semestre</AlertDialogTitle>
+          <AlertDialogDescription>
+            Você está prestes a mudar para o semestre{" "}
+            <strong>{pendingSemester ? formatSemester(pendingSemester) : "selecionado"}</strong>.
+            <br />
+            <br />
+            Isso irá criar uma nova grade em branco. Todos os dados da grade atual serão perdidos, 
+            exceto se ela estiver salva. Deseja continuar?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>
+            Cancelar
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            Continuar
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/app/schedule/components/SemesterSelector.tsx
+++ b/app/schedule/components/SemesterSelector.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useSemestersQuery } from '@/app/hooks/useSemesters';
+import { CalendarDays } from 'lucide-react';
+import { useMemo } from 'react';
+
+interface SemesterSelectorProps {
+  selectedSemester: string | null;
+  onSemesterChange: (semester: string) => void;
+  disabled?: boolean;
+}
+
+function formatSemesterDisplay(semester: string): string {
+  return semester.replace(/\//g, '.');
+}
+
+export default function SemesterSelector({
+  selectedSemester,
+  onSemesterChange,
+  disabled = false,
+}: SemesterSelectorProps) {
+  const { data: semesters, isLoading, error } = useSemestersQuery();
+
+  // Filter and transform semesters: hide .3 when .2 exists, rename orphaned .3 to .2
+  const processedSemesters = useMemo(() => {
+    if (!semesters) return [];
+
+    // Group semesters by year
+    const semestersByYear = new Map<string, { sem1?: typeof semesters[0], sem2?: typeof semesters[0], sem3?: typeof semesters[0] }>();
+    
+    semesters.forEach(semester => {
+      const parts = semester.semester.split('.');
+      const year = parts[0];
+      const suffix = parts[1];
+      
+      if (!semestersByYear.has(year)) {
+        semestersByYear.set(year, {});
+      }
+      
+      const yearData = semestersByYear.get(year)!;
+      if (suffix === '1') yearData.sem1 = semester;
+      else if (suffix === '2') yearData.sem2 = semester;
+      else if (suffix === '3') yearData.sem3 = semester;
+    });
+
+    // Build final list: .1 + .2 (hiding .3 when .2 exists, renaming orphaned .3 to .2)
+    const result: Array<{ id: number; semester: string; displaySemester: string }> = [];
+    
+    semestersByYear.forEach(({ sem1, sem2, sem3 }, year) => {
+      // Always include .1 if it exists
+      if (sem1) {
+        result.push({
+          id: sem1.id,
+          semester: sem1.semester,
+          displaySemester: sem1.semester
+        });
+      }
+      
+      // For .2/.3: if both exist, show only .2; if only .3 exists, show it as .2
+      if (sem2) {
+        result.push({
+          id: sem2.id,
+          semester: sem2.semester,
+          displaySemester: sem2.semester
+        });
+      } else if (sem3) {
+        // Orphaned .3 - display as .2 but keep original value for backend
+        result.push({
+          id: sem3.id,
+          semester: sem3.semester,
+          displaySemester: `${year}.2`
+        });
+      }
+    });
+
+    // Sort by semester descending (newest first)
+    return result.sort((a, b) => b.semester.localeCompare(a.semester));
+  }, [semesters]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-10 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2 h-10 px-3 py-2 border border-destructive rounded-md text-sm text-destructive">
+          <CalendarDays className="h-4 w-4" />
+          Erro ao carregar semestres
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Select
+        disabled={disabled}
+        value={selectedSemester || ''}
+        onValueChange={onSemesterChange}
+      >
+        <SelectTrigger id="semester-select" className="w-full">
+          <div className="flex items-center gap-2">
+            <CalendarDays className="h-4 w-4 text-muted-foreground" />
+            <SelectValue placeholder="Selecione um semestre" />
+          </div>
+        </SelectTrigger>
+        <SelectContent>
+          {processedSemesters.map((semester) => (
+            <SelectItem key={semester.id} value={semester.semester}>
+              {formatSemesterDisplay(semester.displaySemester)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/app/schedule/components/SubjectsTable.tsx
+++ b/app/schedule/components/SubjectsTable.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import { useState, useEffect, useRef } from "react";
 import { useSubjects } from "../providers/subjectsContext";
@@ -18,6 +18,7 @@ import { SubjectsType } from "../types/dataType";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import CompetitionBadge from "./CompetitionBadge";
 
 export default function SubjectsTable() {
   const [rowSelection, setRowSelection] = useState<{ [key: string]: boolean }>(
@@ -165,6 +166,7 @@ export default function SubjectsTable() {
             <TableHead>Código</TableHead>
             <TableHead>Turma</TableHead>
             <TableHead>Créditos</TableHead>
+            <TableHead>Concorrência</TableHead>
             <TableHead></TableHead>
           </TableRow>
         </TableHeader>
@@ -189,8 +191,23 @@ export default function SubjectsTable() {
                 {row.code}
               </TableCell>
               <TableCell onClick={() => setSelectedSubject(row)}>
-                {scheduleSubjects.find((s) => s.code === row.code)?.class ||
-                  "-"}
+                {(() => {
+                  const selectedClass = scheduleSubjects.find((s) => s.code === row.code)?.class;
+                  return selectedClass ? (
+                    <Badge
+                      variant="outline"
+                      className={`${
+                        row.color && Array.isArray(row.color)
+                          ? theme === "light"
+                            ? row.color[0] + " text-black"
+                            : row.color[1] + " text-white"
+                          : ""
+                      }`}
+                    >
+                      {selectedClass}
+                    </Badge>
+                  ) : "-";
+                })()}
               </TableCell>
               <TableCell onClick={() => setSelectedSubject(row)}>
                 <Badge
@@ -205,6 +222,9 @@ export default function SubjectsTable() {
                 >
                   {row.name}
                 </Badge>
+              </TableCell>
+              <TableCell onClick={() => setSelectedSubject(row)}>
+                <CompetitionBadge score={row.competition} />
               </TableCell>
               <TableCell className="flex justify-end space-x-2">
                 <Button

--- a/app/schedule/components/WeekCalendar.tsx
+++ b/app/schedule/components/WeekCalendar.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import { useState, useEffect } from "react";
 import { useSubjects } from "../providers/subjectsContext";
@@ -14,7 +14,6 @@ import {
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { weekDays, timeSlots } from "../constants/week-times-and-days";
@@ -277,18 +276,16 @@ export default function WeekCalendarComponent() {
                       >
                         {hasConflict &&
                         !isOneOfTheSubjectsClassOnFocus(cellData.code) ? (
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <div className="cursor-pointer w-full h-full flex justify-center items-center text-center">
-                                  Conflito
-                                </div>
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                {generateTooltipContent(cellData.code)}
-                              </TooltipContent>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div className="cursor-pointer w-full h-full flex justify-center items-center text-center">
+                                Conflito
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              {generateTooltipContent(cellData.code)}
+                            </TooltipContent>
                             </Tooltip>
-                          </TooltipProvider>
                         ) : (
                           <div className="text-center font-medium">
                             {codeToDisplay || ""}

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -9,6 +9,8 @@ import SelectedSubject from "./components/SelectedSubject";
 import SubjectsTable from "./components/SubjectsTable";
 import WeekCalendarComponent from "./components/WeekCalendar";
 import SearchSubject from "./components/SearchSubject";
+import SemesterSelector from "./components/SemesterSelector";
+import SemesterChangeModal from "./components/SemesterChangeModal";
 import SaveScheduleDialog from "./components/SaveScheduleDialog";
 import SavedSchedulesDialog from "./components/SavedSchedulesDialog";
 import ReceivedSharedSchedulesDialog from "./components/ReceivedSharedSchedulesDialog";
@@ -18,7 +20,7 @@ import { SubjectsType } from "./types/dataType";
 import { useEffect, useState } from "react";
 import useAxios from "@/app/api/AxiosInstance";
 import { SubjectsProvider, useSubjects } from "./providers/subjectsContext";
-import { Loader2, Cloud, CloudOff, AlertCircle, Edit2, Check, X, Eraser, Calculator, Zap } from "lucide-react";
+import { Loader2, Cloud, CloudOff, AlertCircle, Edit2, Check, X, Eraser, Calculator, Zap, FileText } from "lucide-react";
 import { useUnsavedChangesWarning } from "@/app/hooks/useUnsavedChangesWarning";
 import { useSavedSchedulesQuery } from "@/app/hooks/useSavedSchedules";
 import { useSession } from "@/app/hooks/useSession";
@@ -72,6 +74,14 @@ function AccountSaveStatusBadge() {
   }
 
   if (!currentScheduleId) {
+    if (localSaveStatus === "idle") {
+      return (
+        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground mt-1">
+          <FileText className="h-3 w-3" />
+          Grade local
+        </div>
+      );
+    }
     return (
       <div className="flex items-center gap-1.5 text-xs font-medium text-amber-500 mt-1">
         <AlertCircle className="h-3 w-3" />
@@ -354,7 +364,20 @@ function CreditsCounter() {
 }
 
 function ScheduleContent({ subjects }: { subjects: SubjectsType[] }) {
-  const { currentPlan, setCurrentPlan, scheduleSubjects, clearCurrentPlan, plansInitialized } = useSubjects();
+  const { 
+    currentPlan, 
+    setCurrentPlan, 
+    scheduleSubjects, 
+    clearCurrentPlan, 
+    plansInitialized,
+    selectedSemester,
+    setSelectedSemester,
+    showSemesterChangeModal,
+    confirmSemesterChange,
+    cancelSemesterChange,
+    pendingSemester,
+    plansData
+  } = useSubjects();
   const [showClearPlanAlert, setShowClearPlanAlert] = useState(false);
 
   const handleClearPlanClick = () => {
@@ -371,10 +394,18 @@ function ScheduleContent({ subjects }: { subjects: SubjectsType[] }) {
     toast.success(`Matérias do Plano ${currentPlan} removidas com sucesso!`);
   };
 
+  const plan2HasSubjects = plansData[2]?.scheduleSubjects?.length > 0;
+  const isPlan3Disabled = !plan2HasSubjects && currentPlan !== 3;
+
   return (
     <>
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center gap-4">
+          <SemesterSelector
+            selectedSemester={selectedSemester}
+            onSemesterChange={setSelectedSemester}
+            disabled={false}
+          />
           <SearchSubject subjects={subjects} />
           <Button
             variant="outline"
@@ -412,7 +443,8 @@ function ScheduleContent({ subjects }: { subjects: SubjectsType[] }) {
               variant={currentPlan === 3 ? "default" : "outline"} 
               size="sm"
               onClick={() => setCurrentPlan(3)}
-              className={`relative ${!plansInitialized.has(3) && currentPlan !== 3 ? 'text-muted-foreground border-dashed' : ''}`}
+              disabled={isPlan3Disabled}
+              className={`relative ${!plansInitialized.has(3) && currentPlan !== 3 ? 'text-muted-foreground border-dashed' : ''} ${isPlan3Disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
               Plano 3
               {!plansInitialized.has(3) && (
@@ -474,6 +506,13 @@ function ScheduleContent({ subjects }: { subjects: SubjectsType[] }) {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <SemesterChangeModal
+        open={showSemesterChangeModal}
+        onConfirm={() => confirmSemesterChange('')}
+        onCancel={cancelSemesterChange}
+        pendingSemester={pendingSemester}
+      />
     </>
   );
 }

--- a/app/schedule/providers/subjectsContext.tsx
+++ b/app/schedule/providers/subjectsContext.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useCallback, createContext, useState } from "react";
 import { SubjectsType } from "../types/dataType";
 import { restoreColorUsage } from "../utils/colorUtils";
+import { useSemestersQuery } from "@/app/hooks/useSemesters";
 
 export type scheduleSubjectsType = {
   code: string;
@@ -78,6 +79,15 @@ type SubjectsContextType = {
       credits: number;
     }[];
   }[];
+  selectedSemester: string | null;
+  setSelectedSemester: (semester: string | null) => void;
+  setSelectedSemesterDirectly: (semester: string | null) => void;
+  showSemesterChangeModal: boolean;
+  setShowSemesterChangeModal: React.Dispatch<React.SetStateAction<boolean>>;
+  confirmSemesterChange: (newSemester: string) => void;
+  cancelSemesterChange: () => void;
+  pendingSemester: string | null;
+  isResetting: boolean;
 };
 
 const STORAGE_KEY = "schedule_subjects";
@@ -88,6 +98,7 @@ const STORAGE_CURRENT_PLAN_KEY = "current_plan";
 const STORAGE_PLANS_DATA_KEY = "plans_data";
 const STORAGE_PLANS_INITIALIZED_KEY = "plans_initialized";
 const STORAGE_AUTO_SAVE_ENABLED_KEY = "auto_save_enabled";
+const STORAGE_SELECTED_SEMESTER_KEY = "selected_semester";
 
 const emptyPlanData = (): PlanData => ({
   scheduleSubjects: [],
@@ -141,6 +152,15 @@ export const SubjectsContext = createContext<SubjectsContextType>({
   autoSaveEnabled: true,
   setAutoSaveEnabled: () => {},
   getPlansDataForSave: () => [],
+  selectedSemester: null,
+  setSelectedSemester: () => {},
+  setSelectedSemesterDirectly: () => {},
+  showSemesterChangeModal: false,
+  setShowSemesterChangeModal: () => {},
+  confirmSemesterChange: () => {},
+  cancelSemesterChange: () => {},
+  pendingSemester: null,
+  isResetting: false,
 });
 
 export function SubjectsProvider({
@@ -159,6 +179,7 @@ export function SubjectsProvider({
   const [scheduleTitle, setScheduleTitle] = useState<string>("Grade sem título");
   const [isHydrated, setIsHydrated] = useState(false);
   const [isLoadingSchedule, setIsLoadingSchedule] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
   const [autoSaveEnabled, setAutoSaveEnabled] = useState(() => {
     if (typeof window === "undefined") return true;
     try {
@@ -169,8 +190,43 @@ export function SubjectsProvider({
     }
   });
 
+  const [selectedSemester, setSelectedSemester] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    try {
+      return localStorage.getItem(STORAGE_SELECTED_SEMESTER_KEY);
+    } catch (error) {
+      return null;
+    }
+  });
+
+  const [showSemesterChangeModal, setShowSemesterChangeModal] = useState(false);
+  const [pendingSemester, setPendingSemester] = useState<string | null>(null);
+  const [totalCredits, setTotalCredits] = useState<number>(0);
+  const [localSaveStatus, setLocalSaveStatus] = useState<LocalSaveStatus>("idle");
+
+  // Fetch semesters for default selection
+  const { data: semesters } = useSemestersQuery();
+
+  // Set default semester to the latest (backend returns semesters ordered DESC)
+  // Only set if nothing is saved in localStorage (selectedSemester === null)
+  // and if there are no active subjects (safe to overwrite)
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (selectedSemester !== null) return; // respect saved value
+    if (!semesters || semesters.length === 0) return;
+    // If there are active subjects, avoid automatic switch (safety)
+    const hasActiveSubjects = Object.values(plansData).some(plan => 
+      plan.scheduleSubjects && plan.scheduleSubjects.length > 0
+    );
+    if (hasActiveSubjects) return;
+    // Set silently (do not use handleSemesterChange which triggers confirmation)
+    setSelectedSemester(semesters[0].semester);
+  }, [semesters, selectedSemester, plansData, setSelectedSemester]);
+
   useEffect(() => {
     if (typeof window === "undefined" || isHydrated) return;
+    
+    setIsResetting(true);
     
     try {
       const savedInitialized = localStorage.getItem(STORAGE_PLANS_INITIALIZED_KEY);
@@ -227,9 +283,16 @@ export function SubjectsProvider({
       }
 
       setIsHydrated(true);
+      
+      setTimeout(() => {
+        setIsResetting(false);
+      }, 100);
     } catch (error) {
       console.error("Error hydrating from localStorage:", error);
       setIsHydrated(true);
+      setTimeout(() => {
+        setIsResetting(false);
+      }, 100);
     }
   }, [isHydrated]);
 
@@ -259,10 +322,10 @@ export function SubjectsProvider({
       };
     });
     
-    if (!isLoadingSchedule) {
+    if (!isLoadingSchedule && !isResetting) {
       setLocalSaveStatus("modified");
     }
-  }, [internalCurrentPlan, isLoadingSchedule]);
+  }, [internalCurrentPlan, isLoadingSchedule, isResetting]);
 
   const setSearchedSubjects = useCallback((value: React.SetStateAction<SubjectsType[]>) => {
     setPlansData(prev => {
@@ -324,16 +387,13 @@ export function SubjectsProvider({
     });
   }, [internalCurrentPlan]);
 
-  const [totalCredits, setTotalCredits] = useState<number>(0);
-  const [localSaveStatus, setLocalSaveStatus] = useState<LocalSaveStatus>("idle");
-
   const setScheduleTitleWithModify = useCallback((title: string | ((prevState: string) => string)) => {
     const newTitle = typeof title === "function" ? title(scheduleTitle) : title;
     setScheduleTitle(newTitle);
-    if (!isLoadingSchedule) {
+    if (!isLoadingSchedule && !isResetting) {
       setLocalSaveStatus("modified");
     }
-  }, [isLoadingSchedule, scheduleTitle]);
+  }, [isLoadingSchedule, isResetting, scheduleTitle]);
 
   // Mark data as saved and update last saved state
   const markAsSaved = useCallback(() => {
@@ -525,6 +585,8 @@ export function SubjectsProvider({
 
   // Reset everything to default state (only Plan 1, no subjects)
   const resetToDefault = useCallback(() => {
+    setIsResetting(true);
+    
     // Reset plans data to initial state
     const initialPlansData: Record<PlanNumber, PlanData> = {
       1: emptyPlanData(),
@@ -544,6 +606,10 @@ export function SubjectsProvider({
     setScheduleTitle("Grade sem título");
     setLocalSaveStatus("idle");
     
+    if (semesters && semesters.length > 0) {
+      setSelectedSemester(semesters[0].semester);
+    }
+    
     // Clear all localStorage
     if (typeof window !== "undefined") {
       try {
@@ -558,6 +624,66 @@ export function SubjectsProvider({
         console.error("Error clearing localStorage:", error);
       }
     }
+    
+    // Clear the resetting flag after all state updates
+    setTimeout(() => {
+      setIsResetting(false);
+    }, 100);
+  }, [semesters]);
+
+  // Semester change logic
+  const handleSemesterChange = useCallback((newSemester: string | null) => {
+    if (newSemester === selectedSemester) return;
+    
+    // Check if any plan has active subjects
+    const hasActiveSubjects = Object.values(plansData).some(plan => 
+      plan.scheduleSubjects && plan.scheduleSubjects.length > 0
+    );
+    
+    if (hasActiveSubjects && !isLoadingSchedule) {
+      // Show confirmation modal
+      setPendingSemester(newSemester);
+      setShowSemesterChangeModal(true);
+    } else {
+      // No active subjects, change directly
+      setSelectedSemester(newSemester);
+    }
+  }, [selectedSemester, plansData, isLoadingSchedule]);
+
+  const confirmSemesterChange = useCallback((newSemester: string) => {
+    const targetSemester = newSemester || pendingSemester;
+    if (!targetSemester) return;
+    
+    // Trigger auto-save if there are unsaved changes
+    if (autoSaveEnabled && localSaveStatus === "modified" && currentScheduleId) {
+      const autoSaveEvent = new CustomEvent('autoSaveSchedule', { 
+        detail: { 
+          plans: getPlansDataForSave(),
+          currentScheduleId, 
+          scheduleTitle 
+        } 
+      });
+      window.dispatchEvent(autoSaveEvent);
+    }
+    
+    // Reset to default state (clear all plans)
+    resetToDefault();
+    
+    // Set new semester
+    setSelectedSemester(targetSemester);
+    
+    // Close modal
+    setShowSemesterChangeModal(false);
+    setPendingSemester(null);
+  }, [autoSaveEnabled, localSaveStatus, currentScheduleId, getPlansDataForSave, scheduleTitle, resetToDefault, pendingSemester]);
+
+  const cancelSemesterChange = useCallback(() => {
+    setShowSemesterChangeModal(false);
+    setPendingSemester(null);
+  }, []);
+
+  const setSelectedSemesterDirectly = useCallback((semester: string | null) => {
+    setSelectedSemester(semester);
   }, []);
 
   // Clear all plans and reset to default state (for "Nova Grade" button)
@@ -571,10 +697,10 @@ export function SubjectsProvider({
       ...prev,
       [internalCurrentPlan]: emptyPlanData(),
     }));
-    if (!isLoadingSchedule) {
+    if (!isLoadingSchedule && !isResetting) {
       setLocalSaveStatus("modified");
     }
-  }, [internalCurrentPlan, isLoadingSchedule]);
+  }, [internalCurrentPlan, isLoadingSchedule, isResetting]);
 
   // Restore color usage on mount
   useEffect(() => {
@@ -651,6 +777,18 @@ export function SubjectsProvider({
     } catch (error) {}
   }, [autoSaveEnabled, isHydrated]);
 
+  // Persist selected semester
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      if (selectedSemester !== null) {
+        localStorage.setItem(STORAGE_SELECTED_SEMESTER_KEY, selectedSemester);
+      } else {
+        localStorage.removeItem(STORAGE_SELECTED_SEMESTER_KEY);
+      }
+    } catch (error) {}
+  }, [selectedSemester]);
+
   return (
     <SubjectsContext.Provider
       value={{
@@ -693,6 +831,15 @@ export function SubjectsProvider({
         autoSaveEnabled,
         setAutoSaveEnabled,
         getPlansDataForSave,
+        selectedSemester,
+        setSelectedSemester: handleSemesterChange,
+        setSelectedSemesterDirectly,
+        showSemesterChangeModal,
+        setShowSemesterChangeModal,
+        confirmSemesterChange,
+        cancelSemesterChange,
+        pendingSemester,
+        isResetting,
       }}
     >
       {children}

--- a/app/schedule/types/dataType.tsx
+++ b/app/schedule/types/dataType.tsx
@@ -1,4 +1,4 @@
-﻿export type SchedulesType = {
+export type SchedulesType = {
   idschedule: number;
   weekday: string;
   starttime: string;
@@ -28,6 +28,16 @@ export type SubjectsType = {
   classes: ClassesType[];
   color?: string[];
   schedules?: string;
+  semester?: {
+    id: number;
+    semester: string;
+    createdAt: string;
+  };
+  competition?: {
+    averageOrdersWithoutVacancy: number;
+    category: "Baixa" | "Média" | "Alta";
+    semesterCount: number;
+  };
 };
 
 export type DataType = {

--- a/app/services/competitionService.ts
+++ b/app/services/competitionService.ts
@@ -1,0 +1,60 @@
+import { fetchWithAuth } from "@/lib/fetchWithAuth";
+
+export interface CompetitionScore {
+  code: string;
+  averageOrdersWithoutVacancy: number;
+  category: "Baixa" | "Média" | "Alta";
+  semesterCount: number;
+}
+
+export interface BatchCompetitionResponse {
+  scores: CompetitionScore[];
+  requestedCodes: string[];
+  foundCodes: string[];
+  notFoundCodes: string[];
+}
+
+class CompetitionService {
+  private baseUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+  async getSingleCompetitionScore(code: string): Promise<CompetitionScore> {
+    const response = await fetchWithAuth(`${this.baseUrl}subjects/${code}/competition-score`);
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch competition score for ${code}: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async getBatchCompetitionScores(codes: string[]): Promise<BatchCompetitionResponse> {
+    if (codes.length === 0) {
+      return {
+        scores: [],
+        requestedCodes: [],
+        foundCodes: [],
+        notFoundCodes: [],
+      };
+    }
+
+    const codesParam = codes.join(',');
+    const response = await fetchWithAuth(`${this.baseUrl}subjects/competition-scores?codes=${codesParam}`);
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch batch competition scores: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+}
+
+const competitionService = new CompetitionService();
+
+export const useCompetitionService = () => {
+  return {
+    getSingleCompetitionScore: competitionService.getSingleCompetitionScore.bind(competitionService),
+    getBatchCompetitionScores: competitionService.getBatchCompetitionScores.bind(competitionService),
+  };
+};
+
+export default competitionService;

--- a/app/services/savedSchedulesService.ts
+++ b/app/services/savedSchedulesService.ts
@@ -5,6 +5,7 @@ export interface SavedSchedule {
   title: string;
   description: string;
   totalCredits?: number;
+  semester?: string;
   plans?: {
     planNumber: number;
     credits: number;
@@ -26,6 +27,7 @@ export interface SavedSchedule {
 export interface CreateSavedScheduleDto {
   title: string;
   description: string;
+  semester?: string;
   totalCredits?: number;
   items?: {
     subjectCode: string;

--- a/app/services/semestersService.ts
+++ b/app/services/semestersService.ts
@@ -1,0 +1,19 @@
+import { fetchWithAuth } from '@/lib/fetchWithAuth';
+
+export interface Semester {
+  id: number;
+  semester: string;
+  createdAt: string;
+}
+
+export const semestersService = {
+  async getSemesters(): Promise<Semester[]> {
+    const response = await fetchWithAuth(`${process.env.NEXT_PUBLIC_BACKEND_URL}semesters`);
+    
+    if (!response.ok) {
+      throw new Error('Falha ao carregar semestres');
+    }
+    
+    return response.json();
+  },
+};


### PR DESCRIPTION
Implement semester selection with subject filtering, competition scoring badges, and resolve critical save status management issues for improved schedule management UX.

SEMESTER SELECTION:
- Add semester dropdown selector with backend integration
- Filter subjects by selected semester in search results
- Add semester change confirmation modal when active subjects exist
- Implement semester persistence in localStorage
- Add semester column to saved schedules table
- Auto-save trigger on semester change with unsaved work
- Reset semester to latest when creating new schedule
- Bypass semester alerts when loading schedules from account
- Merge .2 and .3 semesters (display as .2, include both datasets)
- Format semester display as "2026.1" instead of "2026/1"
 
COMPETITION SCORING:
- Add competition score badges (Baixa/Media/Alta) to selected subjects table
- Implement color-coded badges: green (0-15), yellow (15-30), red (30+)
- Add tooltips with exact average scores and classification ranges
- Fetch competition data from backend batch endpoint
- Cache competition scores with 5-minute stale time
- Support dark mode for all badge colors
- Handle loading and error states gracefully
- Display semester count in tooltip

SAVE STATUS SYSTEM FIXES:
- Add isResetting flag to prevent status changes during reset operations
- Fix status incorrectly showing "modified" on fresh schedules
- Implement proper idle state for new schedules without subjects
- Add unsaved changes confirmation before loading saved schedules
- Protect status transitions during initial hydration
- Update three status change triggers with isResetting check
- Fix "Nova Grade" button to check localSaveStatus instead of isDirty

SEMESTER INTEGRATION:
- Add semester field to saved schedules create/update operations
- Implement setSelectedSemesterDirectly bypass function
- Filter subjects by semester when loading saved schedules
- Save and restore semester context with all schedule operations
- Handle backward compatibility for schedules without semester

UI ENHANCEMENTS:
- Replace plain text class codes with colored badges in class table
- Add colored badges to turma column in subjects table
- Update save status badge descriptions (idle vs modified states)
- Restrict Plan 3 creation until Plan 2 has subjects
- Remove "Semestre" label above semester selector
- Improve responsive layout for semester selector and search

BUG FIXES:
- Fix subject triplication when loading saved schedules
- Fix semester not being saved or restored with schedules
- Fix "Nova Grade" showing false unsaved changes warning
- Prevent status changes during initialization and reset
- Fix clearLocalSchedule called without unsaved changes check
- Remove excessive backend query logging display